### PR TITLE
chore: disable stale deployment workflow

### DIFF
--- a/.github/workflows/disabled/deploy.yml
+++ b/.github/workflows/disabled/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy Next.js to VPS
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: "20"
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build
+      run: npm run build
+
+    - name: Setup SSH
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+    - name: Sync build to server
+      run: |
+        rsync -avz --delete .next/ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/var/www/bluedot/.next
+
+    - name: Restart app
+      run: |
+        ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd /var/www/bluedot && pm2 restart bluedot"


### PR DESCRIPTION
The Deploy Next.js to VPS workflow is stale and failing due to SSH credential issues. Disabling it as per Handler instructions since we no longer push from research to live.