### PR TITLE
Add Next.js build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Build Next.js
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- Add an active GitHub Actions workflow that runs the Next.js build on pushes and pull requests to main.
- Keep deployment out of the default-branch build path; the historical Deploy Next.js to VPS failure was caused by SSH authentication during the rsync deploy step, not by the Next.js build.

## Verification
- npm ci
- npm run build