### PR TITLE
ci: make BlueDot sync bridge operational

### DIFF
--- a/.github/workflows/sync-to-org.yml
+++ b/.github/workflows/sync-to-org.yml
@@ -2,13 +2,18 @@ name: Sync to BlueDot-IT
 
 on:
   push:
-    branches:
-      - main
-      - org-sync
+    branches: [ main ]
+  schedule:
+    - cron: '*/15 * * * *'
   workflow_dispatch:
     inputs:
       bootstrap:
         description: Reset org-sync from BlueDot-IT main
+        required: false
+        default: false
+        type: boolean
+      sync_now:
+        description: Run organization sync now
         required: false
         default: false
         type: boolean
@@ -23,7 +28,7 @@ concurrency:
 jobs:
   bootstrap:
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, '[bootstrap-org-sync]')) ||
+      (github.event_name == 'push' && contains(github.event.head_commit.message, '[bootstrap-org-sync]')) ||
       (github.event_name == 'workflow_dispatch' && inputs.bootstrap)
     permissions:
       contents: write
@@ -43,20 +48,23 @@ jobs:
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin org-sync:org-sync --force
   sync:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/org-sync'
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.sync_now)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          ref: org-sync
           fetch-depth: 0
           persist-credentials: false
-      - name: Verify and push to organization main
+      - name: Verify and push org-sync to organization main
         env:
           ORG_SYNC_TOKEN: ${{ secrets.ORG_SYNC_TOKEN }}
         run: |
-          test -n "$ORG_SYNC_TOKEN" || { echo "Missing required repository secret: ORG_SYNC_TOKEN" >&2; exit 1; }
+          if [ -z "$ORG_SYNC_TOKEN" ]; then echo "ORG_SYNC_TOKEN is not configured; skipping."; exit 0; fi
+          git fetch --no-tags origin refs/heads/org-sync:refs/remotes/origin/org-sync
           git remote add org "https://x-access-token:${ORG_SYNC_TOKEN}@github.com/BlueDot-IT/bluedot-website.git"
           git fetch --no-tags org main
-          git merge-base --is-ancestor org/main HEAD || { echo "Refusing sync: org main contains commits not present in org-sync." >&2; exit 1; }
-          git push org HEAD:main
+          if [ "$(git rev-parse origin/org-sync)" = "$(git rev-parse org/main)" ]; then exit 0; fi
+          git merge-base --is-ancestor org/main origin/org-sync || { echo "Refusing sync: org main contains commits not present in org-sync." >&2; exit 1; }
+          git push org refs/remotes/origin/org-sync:refs/heads/main


### PR DESCRIPTION
Changes the bridge from a nonfunctional branch-push trigger to a default-branch poller. `org-sync` is bootstrapped from the org, checked every 15 minutes, and only promoted when BlueDot main is an ancestor. Missing `ORG_SYNC_TOKEN` causes a safe skip.