### PR TITLE
ci: activate BlueDot sync bridge

### DIFF
--- a/.github/workflows/sync-to-org.yml
+++ b/.github/workflows/sync-to-org.yml
@@ -1,6 +1,8 @@
 name: Sync to BlueDot-IT
 
 on:
+  push:
+    branches: [ main ]
   schedule:
     - cron: '*/15 * * * *'
   workflow_dispatch:


### PR DESCRIPTION
Adds a `push` trigger on personal `main` so the current PAT-backed sync workflow activates immediately and remains self-testing on future bridge changes. Existing 15-minute schedule and manual dispatch remain intact.